### PR TITLE
Add opacity to sign-in page footer

### DIFF
--- a/src/components/footer/styles/footer.js
+++ b/src/components/footer/styles/footer.js
@@ -1,11 +1,14 @@
 import styled from 'styled-components';
 
+/* Override the body background-color (global-styles.js) for opacity
+    will allow background to peak through*/
 export const Container = styled.div`
   display: flex;
   max-width: 1000px;
   flex-direction: column;
   padding: 70px 50px;
   margin: auto;
+  background-color: rgba(0,0,0,0.5);
 
   @media (max-width: 1000px) {
     padding: 60px 25px;

--- a/src/pages/signin.js
+++ b/src/pages/signin.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Form } from '../components';
 import { HeaderContainer } from '../containers/header';
+import { FooterContainer } from '../containers/footer';
 
 export default function SignIn() {
   const [error, setError] = useState('');
@@ -47,6 +48,15 @@ export default function SignIn() {
           </Form.SmallText>
         </Form.Base>
       </Form>
+      <div>
+        <FooterContainer />
+      </div>
     </HeaderContainer>
+    
   );
 }
+
+/* Add in FooterContainer to demonstrate opacity change */
+/* Wrap it in a div to avoid flexing it's contents */
+/* May be able to improve upon this, since having the footer inside the header
+  seems like poor semantics */


### PR DESCRIPTION
@cosmin-mihalache I've added background-color: rgba(0,0,0,0.5) to the footer which makes the black background transparent.  If anything is underlying it, it will be able to peak through and influence the appearance of the footer.  To accomplish this on the sign-in page, I placed the FooterContainer inside the HeaderContainer.  This allows the background to stretch underneath the footer.  There may be a better semantic way to accomplish this, but this is the simplest way I can think of without resorting to inline styles and passing additional props down.

I have also wrapped the FooterContainer in a div, so the HeaderContainer links don't get flexed into a single column.